### PR TITLE
Remove braces from arrow function inside sort()

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,7 @@ class WordFinder {
 
   longestWord(s) {
     if (s.length <= 12) {
-      this.dictionary.sort((a, b) => {
-        return b.length - a.length;
-      });
+      this.dictionary.sort((a, b) => b.length - a.length);
 
       function hasSubString(word, str) {
         let head = 0;


### PR DESCRIPTION
Arrow functions with one line don't require braces and return keyword.